### PR TITLE
Tell users when a command errors out

### DIFF
--- a/main.py
+++ b/main.py
@@ -66,6 +66,7 @@ async def on_command_error(ctx, error):  # share certain errors with the user
 		if isinstance(original, IndexError):
 			await ctx.send(f"IndexError: {original}\n[This might mean your search found no results]")
 			return
+	await ctx.send("😖 Sorry, that command caused an error! Devs are investigating the issue.")
 	print('Ignoring exception in command {}:'.format(ctx.command), file=sys.stderr)
 	traceback.print_exception(type(error), error, error.__traceback__, file=sys.stderr)
 	if(ctx):


### PR DESCRIPTION
Instead of just ignoring when a command fails, it tells the user the following message:
`😖 Sorry, that command caused an error! Devs are investigating the issue.`