### PR TITLE
fixes lingering prisoner role

### DIFF
--- a/src/prison.py
+++ b/src/prison.py
@@ -87,8 +87,6 @@ class Prison(commands.Cog):
         time_seconds = utils.time_to_seconds(time)
         release_date = datetime.datetime.utcnow() + datetime.timedelta(seconds=time_seconds)
 
-        await member.add_roles(prison_role)
-
         member_roles = [role for role in member.roles if str(role) != "@everyone"]
         roles = [role.id for role in member_roles]
 


### PR DESCRIPTION
Makes the bot wait until after current roles are catalogued to add the prison role. 
This fixes a bug that would cause the bot to not remove the prison role when unprisoning users. 